### PR TITLE
dust var in amd was global due to ; instead of ,

### DIFF
--- a/src/amd/backbone.marionette.dust.js
+++ b/src/amd/backbone.marionette.dust.js
@@ -1,7 +1,7 @@
 (function (root, factory) {
   if (typeof exports === 'object') {
     var backbone = require('backbone'),
-        marionette = require('marionette');
+        marionette = require('marionette'),
         dust = require('dust');
     module.exports = factory(backbone, dust);
   } else if (typeof define === 'function' && define.amd) {


### PR DESCRIPTION
Was dust global on purpose?
